### PR TITLE
Remove KutnyAutowiringBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Table of contents:
 
  * [CraueConfigBundle](https://github.com/craue/CraueConfigBundle) - Manages configuration settings stored in the database and makes them accessible via a service in your Symfony 2 project.
  * [JMSDiExtraBundle](http://jmsyst.com/bundles/JMSDiExtraBundle) - Provides Advanced Dependency Injection Features.
- * [KutnyAutowiringBundle](https://github.com/kutny/autowiring-bundle) - a bundle providing autowiring for service arguments.
  * [PHP-DI](http://php-di.org) - The dependency injection container for humans.
 
 ## Development


### PR DESCRIPTION
Since Symfony 2.8, the Dependency Injection Component has [native autowiring support](http://symfony.com/blog/new-in-symfony-2-8-service-auto-wiring). This bundle is not needed anymore.
