### PR TITLE
Facebook groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ Table of contents:
 
 ## Community
 
-* Facebook - notable, large and active Facebook groups:
-    * [1](https://fb.com/groups/7672226565)
-    * [2](https://fb.com/groups/symfony2.framework)
+* [Facebook](https://fb.com/groups/7672226565) - Notable, large and active Facebook group.
 * [Google+](https://plus.google.com/communities/109013871316146116610) - Large and active group on Google+.
 * IRC:
     * [#symfony](http://irc.lc/freenode/symfony) - Official IRC channel for Symfony support.


### PR DESCRIPTION
Hello,

currently there is only one Facebook group recommended for Symfony specific discussions on Facebook. Maybe there will be more in the future. However removed one is currently not active and looks like it's being in process of getting archived.

Thanks for considering checking this out or merging it.