### PR TITLE
Removed Assets Management 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A list of awesome [Symfony](http://symfony.com) bundles, utilities and resources
 Table of contents:
 
 * [Administration](#administration)
-* [Assets Management](#assets-management)
 * [Certification](#certification)
 * [Community](#community)
 * [Development](#development)
@@ -32,19 +31,6 @@ Table of contents:
 * [AdmingeneratorGeneratorBundle](https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle) - Admingenerator for Symfony2, parse generator.yml files to build classes
 * [EasyAdminBundle](https://github.com/javiereguiluz/EasyAdminBundle) - Simple admin generator for Symfony applications
 * [SonataAdminBundle](https://github.com/sonata-project/SonataAdminBundle) - AdminBundle - The missing Symfony2 Admin Generator
-
-## Assets Management
-
-* [assetic-extra-bundle](https://github.com/alexandresalome/assetic-extra-bundle) - Asset Directory filter for Assetic.
-* [AsseticInjectorBundle](https://github.com/AppVentus/AsseticInjectorBundle) - This bundle allows you to automaticly include javascripts and stylesheets anywhere in your project.
-* [AsseticMinifierBundle](https://github.com/Djeg/AsseticMinifierBundle) - An assetic minifier in pure PHP for CSS and JS files.
-* [FkrCssURLRewriteBundle](https://github.com/fkrauthan/FkrCssURLRewriteBundle) - A small assetic filter to fix all url paths at css documents to correct urls.
-* [IgorwFileServeBundle](https://github.com/igorw/IgorwFileServeBundle) - Bundle for serving protected files.
-* [JmikolaJsAssetsHelperBundle](https://github.com/jmikola/JmikolaJsAssetsHelperBundle) - Exposes the AssetsHelper service from Symfony2's templating component to JavaScript, allowing relative or absolute asset URI's to be generated client-side.
-* [KachkaevAssetsVersionBundle](https://github.com/kachkaev/KachkaevAssetsVersionBundle) - Automates the process of updating assets version.
-* [SalvaJshrinkBundle](https://github.com/nibsirahsieu/SalvaJshrinkBundle) - This bundle integrate jshrink library as Assetic filter and twig extension.
-* [SpritesBundle](https://github.com/pminnieur/SpritesBundle) - Bundle for the Sprites library.
-* [ZakharovviHumansTxtBundle](https://github.com/zakharovvi/ZakharovviHumansTxtBundle) - Generate humans.txt file from git repository.
 
 ## Certification
 * [CLI tool to train certifications](https://github.com/certificationy/certificationy-cli)


### PR DESCRIPTION
I've checked all bundles in this part and looked at:

- Last commit date
- Number of stars
- Compatibility with Symfony ~3.4 or ~4.0 

All of them had serious issues. No stars, last commit > 4 years ago or only compatible with Symfony 2.x.  Assetic is no longer included by default in the Symfony Standard Edition starting from Symfony 2.8, so that means most of the bundles aren't relevant anymore. See https://symfony.com/doc/3.4/best_practices/web-assets.html for more information.